### PR TITLE
Add category field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Michele Biondi <michelebiondi01@gmail.com>, Andrea Salvatori <andrea.salv
 maintainer=Michele Biondi <michelebiondi01@gmail.com>, Andrea Salvatori <andrea.salvatori92@gmail.com>
 sentence=Arduino driver for Decawave's DWM1000 module.
 paragraph=This library is intended to be used with Decawave's DWM1000 UWB modules. It is focused to provide an API to the hardware rather than specific application.
+category=Device Control
 url=https://github.com/F-Army/arduino-dwm1000
 architectures=*


### PR DESCRIPTION
Lack of a category field in library.properties causes the warning:

WARNING: Category '' in library DWM1000 is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no <!-- Doc = documentation -->
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | NA
