### PR TITLE
Refactor of setDelay to take microseconds as input rather than Objects

### DIFF
--- a/examples/BasicSender/BasicSender.ino
+++ b/examples/BasicSender/BasicSender.ino
@@ -81,8 +81,7 @@ void transmitter() {
   String msg = "Hello DWM1000, it's #"; msg += sentNum;
   DWM1000::setData(msg);
   // delay sending the message for the given amount
-  DWM1000Time deltaTime = DWM1000Time(10, DWM1000Time::MILLISECONDS);
-  DWM1000::setDelay(deltaTime);
+  DWM1000::setDelay(10);
   DWM1000::startTransmit();
   delaySent = millis();
 }

--- a/examples/RangingAnchor/RangingAnchor.ino
+++ b/examples/RangingAnchor/RangingAnchor.ino
@@ -135,8 +135,7 @@ void transmitPollAck() {
     DWM1000::setDefaults();
     data[0] = POLL_ACK;
     // delay the same amount as ranging tag
-    DWM1000Time deltaTime = DWM1000Time(replyDelayTimeUS, DWM1000Time::MICROSECONDS);
-    DWM1000::setDelay(deltaTime);
+    DWM1000::setDelay(replyDelayTimeUS);
     DWM1000::setData(data, LEN_DATA);
     DWM1000::startTransmit();
 }

--- a/examples/RangingTag/RangingTag.ino
+++ b/examples/RangingTag/RangingTag.ino
@@ -129,8 +129,7 @@ void transmitRange() {
     DWM1000::setDefaults();
     data[0] = RANGE;
     // delay sending the message and remember expected future sent timestamp
-    DWM1000Time deltaTime = DWM1000Time(replyDelayTimeUS, DWM1000Time::MICROSECONDS);
-    timeRangeSent = DWM1000::setDelay(deltaTime);
+    timeRangeSent = DWM1000::setDelay(replyDelayTimeUS);
     timePollSent.getTimestamp(data + 1);
     timePollAckReceived.getTimestamp(data + 6);
     timeRangeSent.getTimestamp(data + 11);

--- a/src/DWM1000.cpp
+++ b/src/DWM1000.cpp
@@ -1378,7 +1378,7 @@ namespace DWM1000 {
         writeBytes(DIG_DIAG, DIAG_TMC_SUB, diagnosticBytes, LEN_DIAG_TMC);
     }
 
-	DWM1000Time setDelay(const DWM1000Time& delay) {
+	DWM1000Time setDelay(uint16_t delayUS) {
 		if(_deviceMode == TX_MODE) {
 			DWM1000Utils::setBit(_sysctrl, LEN_SYS_CTRL, TXDLYS_BIT, true);
 		} else if(_deviceMode == RX_MODE) {
@@ -1387,11 +1387,13 @@ namespace DWM1000 {
 			// in idle, ignore
 			return DWM1000Time();
 		}
-		byte       delayBytes[5];
+		byte delayBytes[LEN_DX_TIME];
 		DWM1000Time futureTime;
+		DWM1000Time delayTime = DWM1000Time(delayUS, DWM1000Time::MICROSECONDS);
 		getSystemTimestamp(futureTime);
-		futureTime += delay;
+		futureTime += delayTime;
 		futureTime.getTimestamp(delayBytes);
+		/* the least significant 9-bits are ignored in DX_TIME in functional modes */
 		delayBytes[0] = 0;
 		delayBytes[1] &= 0xFE;
 		writeBytes(DX_TIME, NO_SUB, delayBytes, LEN_DX_TIME);

--- a/src/DWM1000.hpp
+++ b/src/DWM1000.hpp
@@ -283,7 +283,7 @@ namespace DWM1000 {
 	
 	
 	/* transmit and receive configuration. */
-	DWM1000Time  setDelay(const DWM1000Time& delay);
+	DWM1000Time  setDelay(uint16_t delayUS);
 	void         receivePermanently(boolean val);
 	void         setData(byte data[], uint16_t n);
 	void         setData(const String& data);


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q               | A
| -------------   | ---
| Bug fix?        | no
| New feature?    | yes
| Doc update?     | no <!-- Doc = documentation -->
| BC breaks?      | yes <!-- BC = backwards compatibility -->
| Deprecations?   | yes setDelay function
