### PR TITLE
Moved setInterruptPolarity to private namespace

### DIFF
--- a/src/DWM1000.cpp
+++ b/src/DWM1000.cpp
@@ -812,6 +812,10 @@ namespace DWM1000 {
 			_clearAllStatus();
 		}
 
+		void _setInterruptPolarity(boolean val) {
+			DWM1000Utils::setBit(_syscfg, LEN_SYS_CFG, HIRQ_POL_BIT, val);
+		}
+
 		void _disableSequencing() {
             _enableClock(SYS_XTI_CLOCK);
             byte zero[2];
@@ -863,7 +867,7 @@ namespace DWM1000 {
 		// default system configuration
 		memset(_syscfg, 0, LEN_SYS_CFG);
 		setDoubleBuffering(false);
-		setInterruptPolarity(true);
+		_setInterruptPolarity(true);
 		_writeSystemConfigurationRegister();
 		// default interrupt mask, i.e. no interrupts
 		_clearInterrupts();
@@ -1214,10 +1218,6 @@ namespace DWM1000 {
 
 	void setDoubleBuffering(boolean val) {
 		DWM1000Utils::setBit(_syscfg, LEN_SYS_CFG, DIS_DRXB_BIT, !val);
-	}
-
-	void setInterruptPolarity(boolean val) {
-		DWM1000Utils::setBit(_syscfg, LEN_SYS_CFG, HIRQ_POL_BIT, val);
 	}
 
 	void setReceiverAutoReenable(boolean val) {

--- a/src/DWM1000.hpp
+++ b/src/DWM1000.hpp
@@ -194,16 +194,6 @@ namespace DWM1000 {
 	void setReceiverAutoReenable(boolean val);
 	
 	/** 
-	Specifies the interrupt polarity of the DWM1000 chip. 
-
-	As part of `setDefaults()` if the device is in idle mode, interrupt polarity is set to 
-	active high.
-
-	@param[in] val `true` for active high interrupts, `false` for active low interrupts.
-	*/
-	void setInterruptPolarity(boolean val);
-	
-	/** 
 	Specifies whether to suppress any frame check measures while sending or receiving messages.
 	If suppressed, no 2-byte checksum is appended to the message before sending and this 
 	checksum is also not expected at receiver side. Note that when suppressing frame checks, 


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

I don't think this should be handled manually by the user.
