### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,10 +20,10 @@ select	KEYWORD2
 end	KEYWORD2
 enableDebounceClock	KEYWORD2
 enableLedBlinking	KEYWORD2
-setGPIOMode KEYWORD2
-applySleepConfiguration KEYWORD2
-deepSleep   KEYWORD2
-spiWakeup   KEYWORD2
+setGPIOMode	KEYWORD2
+applySleepConfiguration	KEYWORD2
+deepSleep	KEYWORD2
+spiWakeup	KEYWORD2
 reset	KEYWORD2
 softwareReset	KEYWORD2
 setNetworkId	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q               | A
| -------------   | ---
| Bug fix?        | yes
| New feature?    | no
| Doc update?     | no <!-- Doc = documentation -->
| BC breaks?      | no <!-- BC = backwards compatibility -->
| Deprecations?   | no
| Relative Issues | NA <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->
