### PR TITLE
Explicitly using static_cast to grab LSB of uint64_t integer values

### DIFF
--- a/src/DW1000NgRanging.cpp
+++ b/src/DW1000NgRanging.cpp
@@ -60,6 +60,8 @@ namespace DW1000NgRanging {
     }
 
     double correctRange(double range) {
+        double result = 0;
+
         Channel currentChannel = DW1000Ng::getChannel();
         double rxPower = -(static_cast<double>(DW1000Ng::getReceivePower()));
         
@@ -68,16 +70,19 @@ namespace DW1000NgRanging {
             index+=2;
         
         if (rxPower < BIAS_TABLE[0][0]) {
-            return range += BIAS_TABLE[0][index]*0.001;
+            result = range += BIAS_TABLE[0][index]*0.001;
         } else if (rxPower >= BIAS_TABLE[17][0]) {
-            return range += BIAS_TABLE[17][index]*0.001;
+            result = range += BIAS_TABLE[17][index]*0.001;
         } else {
             for(auto i=0; i < 17; i++) {
                 if (rxPower >= BIAS_TABLE[i][0] && rxPower < BIAS_TABLE[i+1][0]){
-                    return range += BIAS_TABLE[i][index]*0.001;
+                    result = range += BIAS_TABLE[i][index]*0.001;
+                    break;
                 }
             }
         }
+
+        return result;
     }
 
 }


### PR DESCRIPTION
Explicitly using static_cast to grab LSB of uint64_t integer values and assigning to uint16_t integer, as the Arduino compiler (c++11) treats the implicit conversion warnings as errors. Also reworking some conditional logic to avoid multiple return keywords which cause the compiler to wig out ('unreachable' conditions which would work just fine, but the compiler treats these as errors too)

| Q               | A
| -------------   | ---
| Bug fix?        | yes
| New feature?    | no
| Doc update?     | no <!-- Doc = documentation -->
| BC breaks?      | no <!-- BC = backwards compatibility -->
| Deprecations?   | no
| Relative Issues | #144  <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->