### PR TITLE
[Examples] Char input refactor for setEUI

### DIFF
--- a/examples/BasicConnectivityTest/BasicConnectivityTest.ino
+++ b/examples/BasicConnectivityTest/BasicConnectivityTest.ino
@@ -47,7 +47,6 @@
  *  - make real check of connection (e.g. change some values on DW1000Ng and verify)
  */
 
-#include <SPI.h>
 #include <DW1000Ng.hpp>
 
 // connection pins

--- a/examples/BasicReceiver/BasicReceiver.ino
+++ b/examples/BasicReceiver/BasicReceiver.ino
@@ -47,7 +47,6 @@
  *  
  */
 
-#include <SPI.h>
 #include <DW1000Ng.hpp>
 
 #if defined(ESP8266)

--- a/examples/BasicSender/BasicSender.ino
+++ b/examples/BasicSender/BasicSender.ino
@@ -46,7 +46,7 @@
  *  - move strings to flash (less RAM consumption)
  *  
  */
-#include <SPI.h>
+
 #include <DW1000Ng.hpp>
 
 #if defined(ESP8266)

--- a/examples/SimpleAntennaCalibration/SimpleAntennaCalibration.ino
+++ b/examples/SimpleAntennaCalibration/SimpleAntennaCalibration.ino
@@ -52,7 +52,6 @@
  *  - move strings to flash (less RAM consumption)
  */
 
-#include <SPI.h>
 #include <DW1000Ng.hpp>
 #include <DW1000NgUtils.hpp>
 #include <DW1000NgRanging.hpp>

--- a/examples/StandardRTLSAnchorB_TWR/StandardRTLSAnchorB_TWR.ino
+++ b/examples/StandardRTLSAnchorB_TWR/StandardRTLSAnchorB_TWR.ino
@@ -25,7 +25,11 @@ const uint8_t PIN_RST = 9;
 const uint8_t PIN_SS = SS; // spi select pin
 #endif
 
+// Extended Unique Identifier register. 64-bit device identifier. Register file: 0x01
+char EUI[] = "AA:BB:CC:DD:EE:FF:00:02";
+
 byte main_anchor_address[] = {0x01, 0x00};
+
 uint16_t next_anchor = 3;
 
 double range_self;
@@ -70,7 +74,7 @@ void setup() {
     DW1000Ng::applyConfiguration(DEFAULT_CONFIG);
     DW1000Ng::enableFrameFiltering(ANCHOR_FRAME_FILTER_CONFIG);
     
-    DW1000Ng::setEUI("AA:BB:CC:DD:EE:FF:00:02");
+    DW1000Ng::setEUI(EUI);
 
     DW1000Ng::setPreambleDetectionTimeout(64);
     DW1000Ng::setSfdDetectionTimeout(273);

--- a/examples/StandardRTLSAnchorC_TWR/StandardRTLSAnchorC_TWR.ino
+++ b/examples/StandardRTLSAnchorC_TWR/StandardRTLSAnchorC_TWR.ino
@@ -25,11 +25,14 @@ const uint8_t PIN_RST = 9;
 const uint8_t PIN_SS = SS; // spi select pin
 #endif
 
-double range_self;
+// Extended Unique Identifier register. 64-bit device identifier. Register file: 0x01
+char EUI[] = "AA:BB:CC:DD:EE:FF:00:03"; 
 
 byte main_anchor_address[] = {0x01, 0x00};
 
 uint16_t blink_rate = 200;
+
+double range_self;
 
 device_configuration_t DEFAULT_CONFIG = {
     false,
@@ -71,7 +74,7 @@ void setup() {
     DW1000Ng::applyConfiguration(DEFAULT_CONFIG);
     DW1000Ng::enableFrameFiltering(ANCHOR_FRAME_FILTER_CONFIG);
     
-    DW1000Ng::setEUI("AA:BB:CC:DD:EE:FF:00:03");
+    DW1000Ng::setEUI(EUI);
 
     DW1000Ng::setPreambleDetectionTimeout(64);
     DW1000Ng::setSfdDetectionTimeout(273);

--- a/examples/StandardRTLSAnchorMain_TWR/StandardRTLSAnchorMain_TWR.ino
+++ b/examples/StandardRTLSAnchorMain_TWR/StandardRTLSAnchorMain_TWR.ino
@@ -30,6 +30,8 @@ const uint8_t PIN_RST = 9;
 const uint8_t PIN_SS = SS; // spi select pin
 #endif
 
+// Extended Unique Identifier register. 64-bit device identifier. Register file: 0x01
+char EUI[] = "AA:BB:CC:DD:EE:FF:00:01";
 
 Position position_self = {0,0};
 Position position_B = {3,0};
@@ -88,7 +90,7 @@ void setup() {
     DW1000Ng::applyConfiguration(DEFAULT_CONFIG);
     DW1000Ng::enableFrameFiltering(ANCHOR_FRAME_FILTER_CONFIG);
     
-    DW1000Ng::setEUI("AA:BB:CC:DD:EE:FF:00:01");
+    DW1000Ng::setEUI(EUI);
 
     DW1000Ng::setPreambleDetectionTimeout(64);
     DW1000Ng::setSfdDetectionTimeout(273);

--- a/examples/StandardRTLSTag_TWR/StandardRTLSTag_TWR.ino
+++ b/examples/StandardRTLSTag_TWR/StandardRTLSTag_TWR.ino
@@ -27,6 +27,9 @@ const uint8_t PIN_SS = SS; // spi select pin
 const uint8_t PIN_RST = 9;
 #endif
 
+// Extended Unique Identifier register. 64-bit device identifier. Register file: 0x01
+char EUI[] = "AA:BB:CC:DD:EE:FF:00:00";
+
 volatile uint32_t blink_rate = 200;
 
 device_configuration_t DEFAULT_CONFIG = {
@@ -80,7 +83,7 @@ void setup() {
     DW1000Ng::applyConfiguration(DEFAULT_CONFIG);
     DW1000Ng::enableFrameFiltering(TAG_FRAME_FILTER_CONFIG);
     
-    DW1000Ng::setEUI("AA:BB:CC:DD:EE:FF:00:00");
+    DW1000Ng::setEUI(EUI);
 
     DW1000Ng::setNetworkId(RTLS_APP_ID);
 
@@ -109,7 +112,7 @@ void loop() {
     DW1000Ng::deepSleep();
     delay(blink_rate);
     DW1000Ng::spiWakeup();
-    DW1000Ng::setEUI("AA:BB:CC:DD:EE:FF:00:00");
+    DW1000Ng::setEUI(EUI);
 
     RangeInfrastructureResult res = DW1000NgRTLS::tagTwrLocalize(1500);
     if(res.success)

--- a/examples/TransmitSpectrumPowerCalibration/TransmitSpectrumPowerCalibration.ino
+++ b/examples/TransmitSpectrumPowerCalibration/TransmitSpectrumPowerCalibration.ino
@@ -6,7 +6,6 @@
    CONDITIONS OF ANY KIND, either express or implied.
 */
 
-#include <SPI.h>
 #include <DW1000Ng.hpp>
 
 // connection pins

--- a/examples/TwoWayRangingInitiator/TwoWayRangingInitiator.ino
+++ b/examples/TwoWayRangingInitiator/TwoWayRangingInitiator.ino
@@ -51,7 +51,6 @@
  *  - move strings to flash (less RAM consumption)
  */
 
-#include <SPI.h>
 #include <DW1000Ng.hpp>
 #include <DW1000NgUtils.hpp>
 #include <DW1000NgTime.hpp>

--- a/examples/TwoWayRangingResponder/TwoWayRangingResponder.ino
+++ b/examples/TwoWayRangingResponder/TwoWayRangingResponder.ino
@@ -52,7 +52,6 @@
  *  - move strings to flash (less RAM consumption)
  */
 
-#include <SPI.h>
 #include <DW1000Ng.hpp>
 #include <DW1000NgUtils.hpp>
 #include <DW1000NgRanging.hpp>


### PR DESCRIPTION
| Q               | A
| -------------   | ---
| Bug fix?        | no
| New feature?    | no
| Doc update?     | no
| BC breaks?      | no
| Deprecations?   | no
| Relative Issues | # <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->

In most recent Arduino IDE I have a warning related to the setEUI function call. 
I used Arduino-ide 1.8.9-3 with avr-core 1.6.23-1. 
 
```
warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
     DW1000Ng::setEUI("AA:BB:CC:DD:EE:FF:00:01");
```

The problem comes from a convert from string literal (with type const char[]) to char*. 

I performed a very simple correction to avoid this tedious warning. 
But there are other solution:
Solution 1:
`const char *x = "foo bar";`
Solution 2:
`char *x = (char *)"foo bar";`
Solution 3:
`
char* x = (char*) malloc(strlen("foo bar")+1); // +1 for the terminator
strcpy(x,"foo bar");
`