### PR TITLE
esp32-concurrency

### DIFF
--- a/src/DW1000Ng.hpp
+++ b/src/DW1000Ng.hpp
@@ -393,6 +393,14 @@ namespace DW1000Ng {
 	
 	boolean isTransmitDone();
 
+#if defined(ESP32) || defined(ESP8266)
+	/**
+	Call this function from the main loop to process
+	interrupt functions out of the interrupt service routine.
+	*/
+	void workqueue();
+#endif
+
 	void clearTransmitStatus();
 
 	boolean isReceiveDone();


### PR DESCRIPTION
Added intFlag (boolean volatile flag, to manage the interrupt service
routine) and workqueue() (function to be called from the main loop()).
This workaround avoids problems with esp32 and esp8266.

The arduino behaviour is the same as the original version (#if defined
has been used): it exploits the SPI.usingInterrupt() function to avoid
concurrency. This is due to the maximum clock speed of arduino
(max 20 MHz); the workqueue call could produce delay an unresponsiveness.

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q               | A
| -------------   | ---
| Bug fix?        | yes
| New feature?    | yes
| Doc update?     | no <!-- Doc = documentation -->
| BC breaks?      | no <!-- BC = backwards compatibility -->
| Deprecations?   | no
| Relative Issues | # <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->
