### PR TITLE
Do not discard top 8 significant bits of timestamp values in ranging calculation

### DIFF
--- a/src/DW1000NgRanging.cpp
+++ b/src/DW1000NgRanging.cpp
@@ -41,19 +41,22 @@ namespace DW1000NgRanging {
                                     uint64_t timeRangeReceived
                                 )
     {
-        uint32_t timePollSent_32 = static_cast<uint32_t>(timePollSent);
-        uint32_t timePollReceived_32 = static_cast<uint32_t>(timePollReceived);
-        uint32_t timePollAckSent_32 = static_cast<uint32_t>(timePollAckSent);
-        uint32_t timePollAckReceived_32 = static_cast<uint32_t>(timePollAckReceived);
-        uint32_t timeRangeSent_32 = static_cast<uint32_t>(timeRangeSent);
-        uint32_t timeRangeReceived_32 = static_cast<uint32_t>(timeRangeReceived);
-        
-        double round1 = static_cast<double>(timePollAckReceived_32 - timePollSent_32);
-        double reply1 = static_cast<double>(timePollAckSent_32 - timePollReceived_32);
-        double round2 = static_cast<double>(timeRangeReceived_32 - timePollAckSent_32);
-        double reply2 = static_cast<double>(timeRangeSent_32 - timePollAckReceived_32);
+        uint64_t round1 = timePollAckReceived - timePollSent;
+        uint64_t reply1 = timePollAckSent - timePollReceived;
+        uint64_t round2 = timeRangeReceived - timePollAckSent;
+        uint64_t reply2 = timeRangeSent - timePollAckReceived;
 
-        int64_t tof_uwb = static_cast<int64_t>((round1 * round2 - reply1 * reply2) / (round1 + round2 + reply1 + reply2));
+        int64_t numerador = round1 * round2 - reply1 * reply2;
+        uint64_t denominador = round1 + round2 + reply1 + reply2;
+        bool n = false;
+        if (numerador < 0) {
+            n = true;
+            numerador = -numerador;
+        }
+
+        int64_t tof_uwb = numerador / denominador;
+        if (n) tof_uwb = -tof_uwb;
+
         double distance = tof_uwb * DISTANCE_OF_RADIO;
 
         return distance;

--- a/src/DW1000NgRanging.cpp
+++ b/src/DW1000NgRanging.cpp
@@ -48,6 +48,10 @@ namespace DW1000NgRanging {
 
         int64_t dividend = round1 * round2 - reply1 * reply2;
         uint64_t divisor = round1 + round2 + reply1 + reply2;
+
+        /* Work around a bug in the GCC shipped with the ESP32 IDF for Arduino
+           that fails to preserve sign on int64_t division and would therefore
+           hide measurement inconsistencies elsewhere in the design.  */
         bool isNegative = false;
         if (dividend < 0) {
             isNegative = true;
@@ -55,6 +59,8 @@ namespace DW1000NgRanging {
         }
 
         int64_t tof_uwb = dividend / divisor;
+
+        /* Reapply preserved sign */
         if (isNegative) tof_uwb = -tof_uwb;
 
         double distance = tof_uwb * DISTANCE_OF_RADIO;

--- a/src/DW1000NgRanging.cpp
+++ b/src/DW1000NgRanging.cpp
@@ -46,16 +46,16 @@ namespace DW1000NgRanging {
         uint64_t round2 = timeRangeReceived - timePollAckSent;
         uint64_t reply2 = timeRangeSent - timePollAckReceived;
 
-        int64_t numerador = round1 * round2 - reply1 * reply2;
-        uint64_t denominador = round1 + round2 + reply1 + reply2;
-        bool n = false;
-        if (numerador < 0) {
-            n = true;
-            numerador = -numerador;
+        int64_t dividend = round1 * round2 - reply1 * reply2;
+        uint64_t divisor = round1 + round2 + reply1 + reply2;
+        bool isNegative = false;
+        if (dividend < 0) {
+            isNegative = true;
+            dividend = -dividend;
         }
 
-        int64_t tof_uwb = numerador / denominador;
-        if (n) tof_uwb = -tof_uwb;
+        int64_t tof_uwb = dividend / divisor;
+        if (isNegative) tof_uwb = -tof_uwb;
 
         double distance = tof_uwb * DISTANCE_OF_RADIO;
 


### PR DESCRIPTION
Instead of casting the 5-byte timestamps into 4-byte values, perform
as much of the arithmetic as 64-bit values instead. Also, since
apparently the GCC compiler for the ESP32 fails to preserve the sign
across division of int64_t values, remove the negative sign before
division and add it later. The sign preservation is required for
later timestamp debugging.

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q               | A
| -------------   | ---
| Bug fix?        | yes
| New feature?    | no
| Doc update?     | no <!-- Doc = documentation -->
| BC breaks?      | no <!-- BC = backwards compatibility -->
| Deprecations?   | no
| Relative Issues | # <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->
