### PR TITLE
ESP32: delegate interrupt handling into a separate task

### DIFF
--- a/src/DW1000Ng.cpp
+++ b/src/DW1000Ng.cpp
@@ -1328,6 +1328,19 @@ namespace DW1000Ng {
 		initialize(ss, 0xff, rst);
 	}
 
+	void shutDown(void) {
+		if (_irq != 0xff) {
+			detachInterrupt(digitalPinToInterrupt(_irq));
+		}
+		forceTRxOff();
+#ifdef ESP32
+		if (_handlerDispatcherTask != NULL) {
+			vTaskDelete(_handlerDispatcherTask);
+			_handlerDispatcherTask = NULL;
+		}
+#endif
+	}
+
 	/* callback handler management. */
 	void attachErrorHandler(void (* handleError)(void)) {
 		_handleError = handleError;

--- a/src/DW1000Ng.hpp
+++ b/src/DW1000Ng.hpp
@@ -390,6 +390,10 @@ namespace DW1000Ng {
 	By default this is attached to the interrupt pin callback
 	*/
 	void interruptServiceRoutine();
+#ifdef ESP32
+	void handlerDispatcher(void *);
+	unsigned long long getNumInterrupts(void);
+#endif
 	
 	boolean isTransmitDone();
 

--- a/src/DW1000Ng.hpp
+++ b/src/DW1000Ng.hpp
@@ -70,7 +70,12 @@ namespace DW1000Ng {
 	@param[in] rst The reset line/pin for hard resets of ICs that connect to the Arduino. Value 0xff means soft reset.
 	*/
 	void initializeNoInterrupt(uint8_t ss, uint8_t rst = 0xff);
-	
+
+	/**
+	Unregister any active interrupt handlers in preparation for reconfiguration
+	*/
+	void shutDown(void);
+
 	/** 
 	Enable debounce Clock, used to clock the LED blinking
 	*/


### PR DESCRIPTION
This pull request switches the interrupt request handling from a direct ISR into a separate task. This allows the handler more flexibility in how to handle the interrupt, without violating timing limits that may cause lockups or watchdog reboots. For platforms other than ESP32, the behavior of the code has been preserved.

| Q               | A
| -------------   | ---
| Bug fix?        | yes
| New feature?    | no
| Doc update?     | no <!-- Doc = documentation -->
| BC breaks?      | no <!-- BC = backwards compatibility -->
| Deprecations?   | no
| Relative Issues | # <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->
