### PR TITLE
Added EEPROM option for saving the antenna delay

### DIFF
--- a/examples/SaveAntennaDelay/SaveAntennaDelay.ino
+++ b/examples/SaveAntennaDelay/SaveAntennaDelay.ino
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2018 Michele Biondi, Andrea Salvatori
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
+/*
+ * Copyright (c) 2015 by Thomas Trojer <thomas@trojer.net>
+ * Decawave DW1000 library for arduino.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file SaveAntennaDelay.ino
+ * This example shows how you can save the antenna delay in the EEPROM of your arduino.
+ * When saved in EEPROM you can retrieve it after a reboot.
+ * 
+ */
+
+#include <DW1000Ng.hpp>
+
+// connection pins
+#if defined(ESP8266)
+const uint8_t PIN_RST = 5; // reset pin
+const uint8_t PIN_IRQ = 4; // irq pin
+const uint8_t PIN_SS = 15; // spi select pin
+#else
+const uint8_t PIN_RST = 9; // reset pin
+const uint8_t PIN_IRQ = 2; // irq pin
+const uint8_t PIN_SS = SS; // spi select pin
+#endif
+
+
+void setup() {
+  // DEBUG monitoring
+  Serial.begin(9600);
+  // initialize the driver
+  DW1000Ng::initialize(PIN_SS, PIN_IRQ, PIN_RST);
+  Serial.println(F("DW1000Ng initialized ..."));
+  // general configuration
+  DW1000Ng::setDeviceAddress(5);
+  DW1000Ng::setNetworkId(10);
+  Serial.println(F("Committed configuration ..."));
+  // First we genereate a random integer to set as antenna delay
+  uint16_t randNumber = random(65535);
+  DW1000Ng::setAndSaveAntennaDelay(randNumber);
+  // Now the antenna delay is set to this number, and it is saved in the EEPROM
+  Serial.println("Now in EEPROM: " + String(DW1000Ng::getSavedAntennaDelay()));
+  Serial.println("TX delay: " + String(DW1000Ng::getTxAntennaDelay()));
+  Serial.println("RX delay: " + String(DW1000Ng::getRxAntennaDelay()));
+  // We simulate a reboot by resetting the antenna delay
+  DW1000Ng::setAntennaDelay(0);
+  Serial.println("TX delay: " + String(DW1000Ng::getTxAntennaDelay()));
+  Serial.println("RX delay: " + String(DW1000Ng::getRxAntennaDelay()));
+  // We can now restore it from EEPROM
+  DW1000Ng::setAntennaDelayFromEEPROM();
+  Serial.println("Restored from EEPROM");
+  Serial.println("TX delay: " + String(DW1000Ng::getTxAntennaDelay()));
+  Serial.println("RX delay: " + String(DW1000Ng::getRxAntennaDelay()));
+
+  // You can also of course retrieve the value saved in EEPROM like this
+  uint16_t delaySavedInEEPROM = DW1000Ng::getSavedAntennaDelay();
+}
+
+void loop() {
+  
+}

--- a/src/DW1000Ng.cpp
+++ b/src/DW1000Ng.cpp
@@ -45,6 +45,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <EEPROM.h>
 #include "DW1000Ng.hpp"
 #include "DW1000NgUtils.hpp"
 #include "DW1000NgConstants.hpp"
@@ -1707,6 +1708,28 @@ namespace DW1000Ng {
 		_antennaTxDelay = value;
 		_antennaRxDelay = value;
 		_writeAntennaDelayRegisters();
+	}
+	void setAndSaveAntennaDelay(uint16_t delay, uint8_t eeAddress) {
+		EEPROM.begin(64);
+		EEPROM.put(eeAddress, delay);
+		EEPROM.end();
+		setAntennaDelay(delay);
+	}
+
+	uint16_t getSavedAntennaDelay(uint8_t eeAddress) {
+		EEPROM.begin(64);
+		uint16_t delay;
+		EEPROM.get(eeAddress, delay);
+		EEPROM.end();
+		return delay;
+	}
+
+	uint16_t setAntennaDelayFromEEPROM(uint8_t eeAddress) {
+		EEPROM.begin(64);
+		uint16_t delay;
+		EEPROM.get(eeAddress, delay);
+		setAntennaDelay(delay);
+		EEPROM.end();
 	}
 
 	void setTxAntennaDelay(uint16_t value) {

--- a/src/DW1000Ng.cpp
+++ b/src/DW1000Ng.cpp
@@ -1725,11 +1725,8 @@ namespace DW1000Ng {
 	}
 
 	uint16_t setAntennaDelayFromEEPROM(uint8_t eeAddress) {
-		EEPROM.begin(64);
-		uint16_t delay;
-		EEPROM.get(eeAddress, delay);
+		uint16_t delay = getSavedAntennaDelay(eeAddress);
 		setAntennaDelay(delay);
-		EEPROM.end();
 	}
 
 	void setTxAntennaDelay(uint16_t value) {

--- a/src/DW1000Ng.hpp
+++ b/src/DW1000Ng.hpp
@@ -314,7 +314,31 @@ namespace DW1000Ng {
 	@param [in] value the delay in UWB time
 	*/
 	void setAntennaDelay(uint16_t value);
-	
+
+	/**
+	Sets both tx and rx antenna delay value, and saves it in the EEPROM for future use
+
+	@param [in] value the delay in UWB time
+	@param [in] the EEPROM offset at which the delay is saved
+	*/
+	void setAndSaveAntennaDelay(uint16_t delay, uint8_t eeAddress = 0);
+
+	/**
+	Gets the saved antenna delay value from EEPROM
+
+	returns the value of the delay saved in the EEPROM in UWB time
+
+	@param [in] the EEPROM offset at which the delay is saved
+	*/
+	uint16_t getSavedAntennaDelay(uint8_t eeAddress = 0);
+
+	/**
+	Sets the saved antenna delay value from EEPROM as the configured delay
+
+	@param [in] the EEPROM offset at which the delay is saved
+	*/
+	uint16_t setAntennaDelayFromEEPROM(uint8_t eeAddress = 0);
+
 	/**
 	Sets the tx antenna delay value
 


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q               | A
| -------------   | ---
| Bug fix?        | no
| New feature?    | yes
| Doc update?     |no <!-- Doc = documentation -->
| BC breaks?      | no <!-- BC = backwards compatibility -->
| Deprecations?   | no
| Relative Issues | #62 <!-- Using fixes, fix, closes prefixes will automatically close the reference issues on merge -->

I added some methods to save anttenna delay in the EEPROM, some sample code:
```cpp
  uint16_t randNumber = random(300);
  Serial.println("Now in EEPROM: " + String(DW1000Ng::getSavedAntennaDelay()));
  Serial.println("TX delay: " + String(DW1000Ng::getTxAntennaDelay()));
  Serial.println("RX delay: " + String(DW1000Ng::getRxAntennaDelay()));
  DW1000Ng::setAntennaDelayFromEEPROM();
  Serial.println("Restored from EEPROM");
  Serial.println("TX delay: " + String(DW1000Ng::getTxAntennaDelay()));
  Serial.println("RX delay: " + String(DW1000Ng::getRxAntennaDelay()));
  Serial.println("Got random num: " + String(randNumber));
  Serial.println("Saving");
  DW1000Ng::setAndSaveAntennaDelay(randNumber);
  Serial.println("Now in EEPROM: " + String(DW1000Ng::getSavedAntennaDelay()));
  Serial.println("TX delay: " + String(DW1000Ng::getTxAntennaDelay()));
  Serial.println("RX delay: " + String(DW1000Ng::getRxAntennaDelay()));
  Serial.println("------------------------------------------");
```

Gives the following output:
```
15:18:37.582 -> Now in EEPROM: 177
15:18:37.582 -> TX delay: 0
15:18:37.582 -> RX delay: 0
15:18:37.627 -> Restored from EEPROM
15:18:37.627 -> TX delay: 177
15:18:37.672 -> RX delay: 177
15:18:37.672 -> Got random num: 219
15:18:37.672 -> Saving
15:18:37.717 -> Now in EEPROM: 219
15:18:37.717 -> TX delay: 219
15:18:37.717 -> RX delay: 219
15:18:37.762 -> ------------------------------------------
```

Hope this is what was needed, please comment if this is incorrect.